### PR TITLE
Use network name setting

### DIFF
--- a/wp-content/themes/intranet/views/partials/404/default.blade.php
+++ b/wp-content/themes/intranet/views/partials/404/default.blade.php
@@ -2,7 +2,7 @@
     <div class="grid">
         <div class="grid-lg-2 grid-md-2 grid-sm-12 hidden-xs hidden-sm no-margin no-padding"></div>
         <div class="grid-lg-8 grid-md-8 grid-sm-12">
-           <span class="h1 no-margin no-padding">Helsingborgs stads intranät</span>
+           <span class="h1 no-margin no-padding">{{ get_site_option('site_name') }}</span>
         </div>
     </div>
 </div>

--- a/wp-content/themes/intranet/views/partials/header/intranet.blade.php
+++ b/wp-content/themes/intranet/views/partials/header/intranet.blade.php
@@ -7,7 +7,7 @@
             <div class="grid-auto">
                 <div class="grid grid-table grid-va-middle">
                     <div class="grid-auto no-padding">
-                        <a href="{{ network_home_url() }}" class="h3 site-title inline-block"><span {!! get_field('logotype_tooltip', 'option') ? 'data-tooltip="' . get_field('logotype_tooltip', 'option') . '"' : '' !!}>Helsingborgs stads intranät</span></a>
+                        <a href="{{ network_home_url() }}" class="h3 site-title inline-block"><span {!! get_field('logotype_tooltip', 'option') ? 'data-tooltip="' . get_field('logotype_tooltip', 'option') . '"' : '' !!}>{{ get_site_option('site_name') }}</span></a>
                     </div>
                     <div class="grid-fit-content no-padding">
                         @include('partials.header.subnav')


### PR DESCRIPTION
This removes the hardcoded "Helsingborgs stads intranät" and uses the network site name instead.