### PR TITLE
Fix that nobody can change theme-color

### DIFF
--- a/wp-content/themes/intranet/library/Theme/General.php
+++ b/wp-content/themes/intranet/library/Theme/General.php
@@ -168,8 +168,6 @@ class General
      */
     public function colorScheme($key)
     {
-        return 'purple';
-
         if ((defined('MUNICIPIO_INTRANET_USER_COLOR_THEME') && !MUNICIPIO_INTRANET_USER_COLOR_THEME) || !is_user_logged_in() || empty(get_the_author_meta('user_color_scheme', get_current_user_id()))) {
             return $key;
         }


### PR DESCRIPTION
If you force returning "purple" nobody will be able to change the theme-color in the wordpress admin site.