### PR TITLE
Change the hook for url-rewrites for the sites to after_setup_theme

### DIFF
--- a/wp-content/mu-plugins/IntranetDefaultSettings.php
+++ b/wp-content/mu-plugins/IntranetDefaultSettings.php
@@ -12,7 +12,7 @@ class IntranetDefaultSettings
         add_action('wpmu_new_blog', array($this, 'searchWpSettings'));
 
         // Site list
-        add_action('wpmu_new_blog', array($this, 'sitesListPageUrlRewrite'));
+        add_action('after_setup_theme', array($this, 'sitesListPageUrlRewrite'));
         add_filter('template_include', array($this, 'sitesListPageTemplate'), 10);
     }
 


### PR DESCRIPTION
Fixes the bug where the link to list all portals gave a 404. This was because the /sites url was not redirecting as it should, because the rewrite rule was hooked to something that did not trigger. This changes it so that the rewrite rule is updated on a theme change. This still feels a bit like a hack, but with this fix, the issue can be solved by toggling the theme on the site. 